### PR TITLE
Fixes syllabus link

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -15,7 +15,7 @@
 
 <h2>Syllabus</h2>
 
-The course syllabus can be found <a href="http://cpsc125.whitkemmey.com/syllabus.html">here.</a>
+The course syllabus can be found <a href="https://github.com/wkemmey/cpsc125">here.</a>
 
 <h2>Lectures</h2>
 


### PR DESCRIPTION
Yo, syllabus link [here](http://cpsc125.whitkemmey.com/) is broken! You may want to do something sexier in the future, but for now just punt letting GitHub show the README.

Side note: Dude, we gotta pretty this up. Drop in a Jekyll theme or something... 😁 
